### PR TITLE
Add global window to jest setup

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -19,6 +19,7 @@ global.__DEV__ = true;
 
 global.Promise = jest.requireActual('promise');
 global.regeneratorRuntime = jest.requireActual('regenerator-runtime/runtime');
+global.window = global
 
 global.requestAnimationFrame = function(callback) {
   return setTimeout(callback, 0);

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -19,7 +19,7 @@ global.__DEV__ = true;
 
 global.Promise = jest.requireActual('promise');
 global.regeneratorRuntime = jest.requireActual('regenerator-runtime/runtime');
-global.window = global
+global.window = global;
 
 global.requestAnimationFrame = function(callback) {
   return setTimeout(callback, 0);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

`window` exists in the React Native runtime, but not inside the test environment. Many libraries use `typeof window === 'undefined'` to check if code is running in SSR. Because of the difference in the real environment and test environment, tests can behave different than the real app, which is an unwanted behavior.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[General] [Fixed] - Fix `window` not existing in jest setup

## Test Plan

Are there tests to check if the test environment is setup correctly? 🤔